### PR TITLE
Expand env vars for finding prebuilt ffmpeg

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,10 +18,15 @@ fn main() {
     // If FFMPEG_LIB_DIR is supplied, always use that, else use pkg-config to
     // find where ffmpeg is installed
     if let Some(lib_dir) = env::var("FFMPEG_LIB_DIR").ok() {
-        println!("cargo:rustc-link-lib=libavformat");
-        println!("cargo:rustc-link-lib=libavcodec");
-        println!("cargo:rustc-link-lib=libavutil");
-        println!("cargo:rustc-link-search={}", lib_dir);
+        let libs_env = env::var("FFMPEG_LIBS").ok();
+        let libs = match libs_env {
+            Some(ref v) => v.split(":").collect(),
+            None => vec!["libavformat", "libavcodec", "libavutil"]
+        };
+        for lib in libs {
+            println!("cargo:rustc-link-lib={}", lib);
+        }
+        println!("cargo:rustc-link-search=native={}", lib_dir);
     } else if !target.contains("pc-windows-msvc") {
         for name in ["libavformat", "libavcodec", "libavutil"].iter() {
             let lib = find_library(name);
@@ -29,6 +34,11 @@ fn main() {
                 config.include(path);
             }
         }
+    }
+
+    let include_dir = env::var("FFMPEG_INCLUDE_DIR").ok();
+    if let Some(include_dir) = include_dir {
+        config.include(include_dir);
     }
     config.file("ffi/vmrs.c").compile("libvmrs.a");
 }


### PR DESCRIPTION
To use a prebuilt ffmpeg requires more than just the lib dir; we also need to be able to set an include path, as well as the library names.
